### PR TITLE
Bypass prompt to continue adding java repo.

### DIFF
--- a/fodor/provisioner.sh
+++ b/fodor/provisioner.sh
@@ -2,7 +2,7 @@
 apt-get install -y python-software-properties debconf-utils pwgen
 
 
-add-apt-repository ppa:webupd8team/java
+add-apt-repository -y ppa:webupd8team/java
 apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list
 


### PR DESCRIPTION

[fodor-provisioning-log-ae577efe-16c4-47f7-9d26-68e812cd75a7.log.zip](https://github.com/fodorxyz/graylog2/files/493428/fodor-provisioning-log-ae577efe-16c4-47f7-9d26-68e812cd75a7.log.zip)

Added ‘-y’ switch to add-apt-repository for Java repo. Was causing provisioning script to time out and fail.

Signed-off-by: Cameron Brister <cameron@squareplanit.com>